### PR TITLE
Adds "human readable" versions of variables to template substitutions.

### DIFF
--- a/getter-setter.py
+++ b/getter-setter.py
@@ -205,6 +205,17 @@ class Variable(object):
     def getName(self):
         return self.name
 
+    def getHumanName(self):
+        style = Prefs.style
+        name = self.getName()
+
+        if 'camelCase' == style :
+            name = ' '.join(re.findall('(?:[A-Z]|^)[^A-Z]*', name)).lower()
+        else :
+            name = name.replace('_', ' ')
+
+        return name
+
     def getDescription(self):
         if self.description is None or "" == self.description:
             self.description = 'value of %s' %self.getName() #get description from name
@@ -292,7 +303,8 @@ class Base(sublime_plugin.TextCommand):
             "type"           : variable.getType(),
             "normalizedName" : variable.getPartialFunctionName(),
             "description"    : variable.getDescription(),
-            "typeHint"       : variable.GetTypeHint()
+            "typeHint"       : variable.GetTypeHint(),
+            "humanName"      : variable.getHumanName()
         }
 
         return template.replace(substitutions)

--- a/templates/camelCase/fluent-setter.tpl
+++ b/templates/camelCase/fluent-setter.tpl
@@ -2,7 +2,7 @@
     /**
      * Sets the %(description)s.
      *
-     * @param %(type)s $%(name)s the %(name)s
+     * @param %(type)s $%(name)s the %(humanName)s
      *
      * @return self
      */

--- a/templates/camelCase/setter.tpl
+++ b/templates/camelCase/setter.tpl
@@ -2,7 +2,7 @@
     /**
      * Sets the %(description)s.
      *
-     * @param %(type)s $%(name)s the %(name)s
+     * @param %(type)s $%(name)s the %(humanName)s
      *
      * @return self
      */


### PR DESCRIPTION
_This is a feature request/addition._

For **camelCase**, `myVar` translates into `my var`. Similarly, `my_var` translates into `my var` when **snake_case** is used.

The templates have also been updated to reflect this addition.
