### PR TITLE
better property naming options and coding conventions

### DIFF
--- a/php-getter-setter.py
+++ b/php-getter-setter.py
@@ -92,12 +92,20 @@ class Variable(object):
 
         return Prefix
 
+    def getParam( self ) :
+        name = self.name
+
+        if ( name[0] == '_' ) :
+            name = name[1:]
+
+        return name
+
     def getHumanName(self):
         style = self.style
         name = self.getName()
 
         if 'camelCase' == style :
-            name = ' '.join(re.findall('(?:[A-Z]|^)[^A-Z]*', name)).lower()
+            name = ' '.join(re.findall('(?:[^_a-z]{0,2})[^_A-Z]*', name)).lower()
         else :
             name = name.replace('_', ' ')
 
@@ -366,6 +374,7 @@ class Base(sublime_plugin.TextCommand):
     def generateFunctionCode(self, template, variable):
         substitutions = {
             "name"           : variable.getName(),
+            "param"          : variable.getParam(),
             "visibility"     : variable.getVisibility(),
             "visibilityPrefix" : variable.getVisibilityPrefix(),
             "type"           : variable.getType(),
@@ -539,9 +548,9 @@ class camelCase(object):
      *
      * @return self
      */
-    %(visibility)s function %(visibilityPrefix)sset%(normalizedName)s(%(typeHint)s $%(name)s)
+    %(visibility)s function %(visibilityPrefix)sset%(normalizedName)s(%(typeHint)s $%(param)s)
     {
-        $this->%(name)s = $%(name)s;
+        $this->%(name)s = $%(param)s;
 
         return $this;
     }
@@ -557,9 +566,9 @@ class camelCaseFluent(camelCase):
      *
      * @return self
      */
-    %(visibility)s function %(visibilityPrefix)sset%(normalizedName)s(%(typeHint)s $%(name)s)
+    %(visibility)s function %(visibilityPrefix)sset%(normalizedName)s(%(typeHint)s $%(param)s)
     {
-        $this->%(name)s = $%(name)s;
+        $this->%(name)s = $%(param)s;
 
         return $this;
     }
@@ -585,9 +594,9 @@ class snakeCase(object):
      *
      * @param %(type)s $%(name)s the %(name)s
      */
-    %(visibility)s function %(visibilityPrefix)sset_%(normalizedName)s(%(typeHint)s $%(name)s)
+    %(visibility)s function %(visibilityPrefix)sset_%(normalizedName)s(%(typeHint)s $%(param)s)
     {
-        $this->%(name)s = $%(name)s;
+        $this->%(name)s = $%(param)s;
     }
 """
 
@@ -603,9 +612,9 @@ class snakeCaseFluent(snakeCase):
      *
      * @return self
      */
-    %(visibility)s function %(visibilityPrefix)sset_%(normalizedName)s(%(typeHint)s $%(name)s)
+    %(visibility)s function %(visibilityPrefix)sset_%(normalizedName)s(%(typeHint)s $%(param)s)
     {
-        $this->%(name)s = $%(name)s;
+        $this->%(name)s = $%(param)s;
 
         return $this;
     }


### PR DESCRIPTION
I added the possibility to use the underscore for private properties and the first character as data type hint. I also added the visibility option of the property for the setter. The setter has to have the same visibility as the defined property.

So for example, when we define a private property such as

```
    /**
     * Example array
     * @var array
     */
    private $_aArray = [ ... ];
```

Getter and setter are created like this

```
    /**
     * Gets the Example array.
     *
     * @return array
     */
    public function getArray()
    {
        return $this->_aArray;
    }

    /**
     * Sets the Example array.
     *
     * @param array $_aArray the array 
     *
     * @return self
     */
    private function _setArray(array $aArray )
    {
        $this->_aArray = $aArray;
    }
```

Well, these are conventions used by many developers, but this is just an option. Developers are still able to use their own conventions, if they like to.

Keep in mind, that the issue #21 may be quite similiar to this pull request, but for an older version. So this PR would resolve issue #21.

For everyone, who can't wait for an accepted PR, but want to use these changes. Just copy my [php-getter-setter.py](https://github.com/chriha/sublime-php-getters-setters/blob/master/php-getter-setter.py) into your `../Packages/PHP Getters and Setters/` directory.
