### PR TITLE
Remove trailing dots so the below example is correct:

### DIFF
--- a/php-getter-setter.py
+++ b/php-getter-setter.py
@@ -199,7 +199,7 @@ class DocBlock(object):
         description = []
 
         for line in lines:
-            line = line.strip(' \t*/')
+            line = line.strip(' \t*/').rstrip('.')
             if (line.startswith('@')) :
                 nameMatches = re.findall('\@(\w+) (:?.*)[ ]?.*', line)
                 if len(nameMatches) > 0 :


### PR DESCRIPTION
```
/**
 * Email address.
 *
 * @var string
 */
protected $email;
```
