### PR TITLE
fixed bug with recent ST3 releases and the new .sublime-syntax format

### DIFF
--- a/php-getter-setter.py
+++ b/php-getter-setter.py
@@ -403,7 +403,7 @@ class Base(sublime_plugin.TextCommand):
         self.view.insert(edit, lastPos, text)
 
     def isPhpSyntax(self):
-        return re.search(".*\PHP.tmLanguage", self.view.settings().get('syntax')) is not None
+        return any(regex.match(self.view.settings().get('syntax')) for regex in [re.compile(".*\PHP.tmLanguage"), re.compile(".*\PHP.sublime-syntax")])
 
     def is_enabled(self):
         return self.isPhpSyntax()


### PR DESCRIPTION
ST3 added the new .sublime-syntax format and moved all their language syntax files over to it so this plugin can no longer detect if the PHP syntax environment is being used. This fixes that.
