### PR TITLE
fixed language detection

### DIFF
--- a/php-getter-setter.py
+++ b/php-getter-setter.py
@@ -403,7 +403,7 @@ class Base(sublime_plugin.TextCommand):
         self.view.insert(edit, lastPos, text)
 
     def isPhpSyntax(self):
-        return re.search(".*\PHP.tmLanguage", self.view.settings().get('syntax')) is not None
+        return re.search(".*\PHP.sublime-syntax", self.view.settings().get('syntax')) is not None
 
     def is_enabled(self):
         return self.isPhpSyntax()


### PR DESCRIPTION
Language detection was using an old syntax file extension. Updated to
the new extension and this solved the syntax buffer (issue #57).