### PR TITLE
fix escape ignoring

### DIFF
--- a/php-getter-setter.py
+++ b/php-getter-setter.py
@@ -429,6 +429,8 @@ class PhpGenerateFor(Base):
         self.view.window().show_quick_panel(self.vars, self.write)
 
     def write(self, index):
+        if index == -1: #escaped
+            return
         name = self.vars[index][0]
         parser = self.getParser(self.getContent())
         for variable in parser.getClassVariables():


### PR DESCRIPTION
bug: select field, Generate for..., esc. Getter or/and setter will be pasted (for last field in list).