### PR TITLE
PHP 7.4 typed properties and PHP 8 union-types support

### DIFF
--- a/php-getter-setter.py
+++ b/php-getter-setter.py
@@ -231,7 +231,7 @@ class Parser(object):
     def __init__(self, content):
         self.content = content
         self.functionRegExp = ".*function.*%s\("
-        self.variableRegExp = '((?:private|public|protected)[ ]{0,}(?:final|static)?[ ]{0,}(?:\$.*?)[ |=|;].*)\n'
+        self.variableRegExp = '((?:private|public|protected)[ ]{0,}(?:[ ]{0,}\S{0,}){0,2}[ ]{0,}(?:\$.*?)[ |=|;].*)\n'
 
     def getContent(self):
         return self.content

--- a/php-getter-setter.py
+++ b/php-getter-setter.py
@@ -231,7 +231,7 @@ class Parser(object):
     def __init__(self, content):
         self.content = content
         self.functionRegExp = ".*function.*%s\("
-        self.variableRegExp = '((?:private|public|protected)[ ]{0,}(?:[ ]{0,}\S{0,}){0,2}[ ]{0,}(?:\$.*?)[ |=|;].*)\n'
+        self.variableRegExp = '((?:private|public|protected)(?:[ ]+\S{0,}){0,2}[ ]{0,}(?:\$.*?)[ |=|;].*)\n'
 
     def getContent(self):
         return self.content


### PR DESCRIPTION
Tests: https://regexr.com/6ho73

The property type is not applied to the getters or setters at the moment. I will try to have that implemented also. This is the first python code I had ever touched in my life (actually they are regexp code).